### PR TITLE
Check data and dataFrom for Vault provider path

### DIFF
--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -361,7 +361,7 @@ func TestBindVaultProvider(t *testing.T) {
 			VaultRole:       "my-role",
 			KvVersion:       2,
 			DataFrom: []string{
-				"path/to/data",
+				"kv/demo-service/credentials",
 			},
 			Data: []apis.KESExternalSecretData{
 				{


### PR DESCRIPTION
The data array can be empty if there is dataFrom instead. Use both to check for the Vault provider "path"

Each KES data or dataFrom spec must come from the same path prefix or it will error.