### PR TITLE
Update Readme to enable users to build binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ The migration process can be done in two ways: manually, or automatically.
 
 Automatic Migration is useful for any user that don't have any templated kes-files.
 
+### Build Binary
+The binary in bin folder might not work on all architectures. The `bin/kestoeso` was observed to be not working on Mac M1 Pro. 
+You can build the binary easily using the command `go build main.go`. The binary named main can be used instead of the `bin/kestoeso`.
+
 ```
 vi migrate.sh # EDIT KES NAMESPACE AND ESO NAMESPACE ENV VARS
 ./migrate.sh


### PR DESCRIPTION
It would be good to mention in the documentation that the kestoeso binary wont work on all the systems. One can easily build using `go build main.go`  and using the main binary created 

Signed-off-by: Muhammad Fahad Rana <17247721+knowfahad@users.noreply.github.com>