### PR TITLE
Add kubeconfig flag

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"kestoeso/pkg/apply"
 	"os"
-	"path/filepath"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -30,12 +29,6 @@ var applyCmd = &cobra.Command{
 		opt.Namespace, _ = cmd.Flags().GetString("namespace")
 		opt.TargetOwner, _ = cmd.Flags().GetString("target-owner")
 		targetSecrets, _ := cmd.Flags().GetStringSlice("secrets")
-		kubeconfig := ""
-		if os.Getenv("KUBECONFIG") == "" {
-			kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
-		} else {
-			kubeconfig = os.Getenv("KUBECONFIG")
-		}
 		config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 		if err != nil {
 			log.Fatal(err)
@@ -60,12 +53,10 @@ var applyCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(applyCmd)
 	var empty = make([]string, 0)
 	applyCmd.Flags().BoolP("all-namespaces", "A", false, "Updates secrets for All Namespaces")
 	applyCmd.Flags().Bool("all-secrets", false, "updates all secrets from one namespace")
 	applyCmd.Flags().StringP("namespace", "n", "default", "Target namespace to look up for secrets")
 	applyCmd.Flags().StringSliceP("secrets", "s", empty, "list of secret names to be updated")
 	applyCmd.Flags().String("target-owner", "kubernetes-client.io/v1", "Target ownership value that secrets are going to be updated")
-
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -7,7 +7,6 @@ import (
 	"kestoeso/pkg/parser"
 	"kestoeso/pkg/provider"
 	"os"
-	"path/filepath"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -21,10 +20,10 @@ var generateCmd = &cobra.Command{
 	Use:   "generate",
 	Short: "A tool to convert KES YAML files into ESO YAML files",
 	Long: `kes-to-eso generate is a tool to allow quick conversion between 
-	kubernetes-external-secrets and external-secrets-operator.
-	It reads kubernetes-external-secrets deployment declaration and uses
-	this information alongside with any KES externalSecrets declaration to
-	provide ESO SecretStores and ExternalSecrets definitions.
+kubernetes-external-secrets and external-secrets-operator.
+It reads kubernetes-external-secrets deployment declaration and uses
+this information alongside with any KES externalSecrets declaration to
+provide ESO SecretStores and ExternalSecrets definitions.
 	Examples:
 		kes-to-eso generate -i path/to/kes/files -o eso/output/dir --to-stdout=false
 		kes-to-eso generate -i path/to/a/single.yaml --kes-namespace=my_custom_namespace
@@ -79,12 +78,6 @@ var generateCmd = &cobra.Command{
 		if opt.SecretStore && !opt.CopySecretRefs {
 			log.Warnf("Warning! Backend Secret References are not being copied to the secret store namespaces! This could lead to unintended behavior (--secret-store=true --copy-secret-refs=false)")
 		}
-		kubeconfig := ""
-		if os.Getenv("KUBECONFIG") == "" {
-			kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
-		} else {
-			kubeconfig = os.Getenv("KUBECONFIG")
-		}
 		config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 		if err != nil {
 			log.Fatal(err)
@@ -113,5 +106,4 @@ func init() {
 	generateCmd.Flags().String("kes-container-name", "kubernetes-external-secrets", "name of KES container object")
 	generateCmd.Flags().StringP("kes-namespace", "n", "default", "namespace where KES is installed")
 	generateCmd.Flags().String("target-namespace", "", "namespace to install files (not recommended - overrides KES-ExternalSecrets definitions)")
-
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,27 +1,27 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
-var cfgFile string
-
-var rootCmd = &cobra.Command{
-	Use:   "kestoeso",
-	Short: "A tool to convert KES YAML files into ESO YAML files",
-	Long: `kes-to-eso is a tool to allow quick conversion between 
+var (
+	kubeconfig string
+	rootCmd    = &cobra.Command{
+		Use:   "kestoeso",
+		Short: "A tool to convert KES YAML files into ESO YAML files",
+		Long: `kes-to-eso is a tool to allow quick conversion between 
 kubernetes-external-secrets and external-secrets-operator.
 It reads kubernetes-external-secrets deployment declaration and uses
 this information alongside with any KES externalSecrets declaration to
 provide ESO SecretStores and ExternalSecrets definitions.
-Examples:
-	kes-to-eso generate -i path/to/kes/files | kubectl apply -f -
-	kes-to-eso apply --target-namespace=my-ns`,
-}
+	Examples:
+		kes-to-eso generate -i path/to/kes/files | kubectl apply -f -
+		kes-to-eso apply --target-namespace=my-ns`,
+	}
+)
 
 func Execute() {
 	cobra.CheckErr(rootCmd.Execute())
@@ -29,23 +29,21 @@ func Execute() {
 
 func init() {
 	rootCmd.AddCommand(generateCmd)
-	cobra.OnInitialize(initConfig)
+	rootCmd.AddCommand(applyCmd)
+	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "",
+		"kubeconfig path, defaults to $KUBECONFIG or $HOME/.kube/config")
 
+	cobra.OnInitialize(initConfig)
 }
 
 func initConfig() {
-	if cfgFile != "" {
-		viper.SetConfigFile(cfgFile)
-	} else {
-		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
-
-		viper.AddConfigPath(home)
-		viper.SetConfigType("yaml")
-		viper.SetConfigName(".test")
+	kenv := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		if kenv != "" {
+			kubeconfig = kenv
+		} else {
+			home, _ := os.UserHomeDir()
+			kubeconfig = filepath.Join(home, ".kube", "config")
+		}
 	}
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
-	}
-
 }


### PR DESCRIPTION
Adds a --kubeconfig global flag to the root command.

Uses the init func to set the kubeconfig variable based on whatever value is supplied with the new flag.

If no value is set, it will default to using KUBECONFIG before going to the $HOME/.kube/config path as a last resort.